### PR TITLE
base_url not required

### DIFF
--- a/Download.py
+++ b/Download.py
@@ -48,7 +48,6 @@ def addtags(filename, json_data, playlist_name):
 
 
 def setProxy():
-    base_url = 'http://h.jiosaavncdn.com'
     proxy_ip = ''
     if ('http_proxy' in os.environ):
         proxy_ip = os.environ['http_proxy']


### PR DESCRIPTION
`base_url = 'http://h.jiosaavncdn.com'`
The base_url is not used anywhere else, as for songs URL dec_url is used